### PR TITLE
增加幽境危战系列 API

### DIFF
--- a/model/mys/apiTool.js
+++ b/model/mys/apiTool.js
@@ -77,6 +77,16 @@ export default class apiTool {
           url: `${hostRecord}game_record/app/genshin/api/role_combat`,
           query: `role_id=${this.uid}&need_detail=true&server=${this.server}`,
         },
+        /** 幽境危战 */
+        hard_challenge: {
+          url: `${hostRecord}game_record/app/genshin/api/hard_challenge`,
+          query: `role_id=${this.uid}&server=${this.server}`,
+        },
+        /** 幽境危战增益角色 */
+        hard_challenge_popularity: {
+          url: `${hostRecord}game_record/app/genshin/api/hard_challenge/popularity`,
+          query: `role_id=${this.uid}&server=${this.server}`,
+        },
         /** 角色详情 */
         character: {
           url: `${hostRecord}game_record/app/genshin/api/character/list`,

--- a/model/mys/mysInfo.js
+++ b/model/mys/mysInfo.js
@@ -41,6 +41,8 @@ export default class MysInfo {
       "action_cardList",
       "avatarInfo",
       "role_combat",
+      "hard_challenge",
+      "hard_challenge_popularity",
       "characterDetail",
     ]
 


### PR DESCRIPTION
- `hard_challenge`: 幽境危战成绩查询
- `hard_challenge_popularity`: 幽境危战增益角色查询

应该都要 ck，目前不清楚是否有 detail 之类的选项，没看到就是没有